### PR TITLE
Add basic Jest test for blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ dobbypr.github.io/
 2.  **Update `blog_data.json`**: Open `blog_data.json` in the root folder. Add a new JSON object for your post at the beginning of the array. Fill in the `title`, `date`, `summary`, `file` (e.g., `"posts/new-entry.html"`), and `tags`. Ensure correct JSON syntax (double quotes, commas between objects).
 3.  **Test**: View `blog.html` to see the new listing and click the link to verify the post page.
 
+## Running Tests
+
+This project uses [Jest](https://jestjs.io/). Install dependencies and run:
+```bash
+npm install
+npm test
+```
+The tests ensure that each entry in `blog_data.json` points to an existing file in the `posts/` directory.
+
+
 ## Credits
 
 -   Inspired by the aesthetic of [ULTRAKILL](https://store.steampowered.com/app/1229490/ULTRAKILL/) by Arsi "Hakita" Patala.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dobbypr.github.io",
+  "version": "1.0.0",
+  "description": "A chaotic, retro-styled personal website inspired by ULTRAKILL's aesthetic with a blood-red-on-black color scheme, interactive effects, and a dynamic blog.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.4"
+  }
+}

--- a/tests/blog.test.js
+++ b/tests/blog.test.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+const blogData = require('../blog_data.json');
+
+describe('Blog posts', () => {
+  test('all referenced post files exist', () => {
+    blogData.forEach(post => {
+      const filePath = path.join(__dirname, '..', post.file);
+      expect(fs.existsSync(filePath)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- setup Jest with a `package.json` and config file
- add a test that checks blog posts in `blog_data.json`
- document how to run the tests in `README`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5d366d4c8323be6eaadb1d0df9d7