### PR TITLE
Revamp loading screen

### DIFF
--- a/css/interactive.css
+++ b/css/interactive.css
@@ -24,6 +24,31 @@
     pointer-events: none;
 }
 
+/* Hell gate animation */
+.gate {
+    position: absolute;
+    top: 0;
+    width: 50%;
+    height: 100%;
+    background: radial-gradient(circle at center, #3a0000 0%, #0a0000 80%);
+    transition: transform 2s ease-in-out;
+    z-index: 2;
+}
+.gate-left {
+    left: 0;
+    transform: translateX(0);
+}
+.gate-right {
+    right: 0;
+    transform: translateX(0);
+}
+.gate-left.open {
+    transform: translateX(-100%);
+}
+.gate-right.open {
+    transform: translateX(100%);
+}
+
 .loading-container {
     max-width: 600px;
     width: 90%;

--- a/js/core.js
+++ b/js/core.js
@@ -77,206 +77,52 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    // Enhanced loading screen
+    // Enhanced loading screen - Hell gate transition
     function initLoadingScreen() {
-        // Create loading screen elements
         const loadingScreen = document.createElement('div');
         loadingScreen.className = 'loading-screen';
 
-        // Add stylized container for loading elements
-        const loadingContainer = document.createElement('div');
-        loadingContainer.className = 'loading-container';
-        
+        const leftGate = document.createElement('div');
+        leftGate.className = 'gate gate-left';
+
+        const rightGate = document.createElement('div');
+        rightGate.className = 'gate gate-right';
+
         const loadingTitle = document.createElement('div');
         loadingTitle.className = 'loading-title';
-        loadingTitle.innerHTML = 'ULTRA<span class="loading-title-layer">LAYER</span>';
+        loadingTitle.textContent = 'ENTERING HELL...';
 
-        const loadingBarContainer = document.createElement('div');
-        loadingBarContainer.className = 'loading-bar-container';
-
-        const loadingBar = document.createElement('div');
-        loadingBar.className = 'loading-bar';
-        
-        // Add glitch overlay to loading bar
-        const loadingBarGlitch = document.createElement('div');
-        loadingBarGlitch.className = 'loading-bar-glitch';
-
-        const loadingMessage = document.createElement('div');
-        loadingMessage.className = 'loading-message';
-        
-        // Add decorative terminal prefix to loading messages
-        const loadingPrefix = document.createElement('span');
-        loadingPrefix.className = 'loading-prefix';
-        loadingPrefix.textContent = '>';
-        loadingMessage.appendChild(loadingPrefix);
-        
-        const loadingText = document.createElement('span');
-        loadingText.className = 'loading-text';
-        loadingMessage.appendChild(loadingText);
-
-        // Add percentage counter
-        const loadingPercent = document.createElement('div');
-        loadingPercent.className = 'loading-percent';
-        loadingPercent.textContent = '0%';
-
-        const bloodDrips = document.createElement('div');
-        bloodDrips.className = 'blood-drips';
-
-        // Assemble loading screen
-        loadingBarContainer.appendChild(loadingBar);
-        loadingBarContainer.appendChild(loadingBarGlitch);
-        loadingContainer.appendChild(loadingTitle);
-        loadingContainer.appendChild(loadingBarContainer);
-        loadingContainer.appendChild(loadingMessage);
-        loadingContainer.appendChild(loadingPercent);
-        loadingScreen.appendChild(loadingContainer);
-        loadingScreen.appendChild(bloodDrips);
+        loadingScreen.appendChild(leftGate);
+        loadingScreen.appendChild(rightGate);
+        loadingScreen.appendChild(loadingTitle);
         document.body.appendChild(loadingScreen);
 
-        // Create random blood drips animation
         if (typeof createBloodDrips === 'function') {
-            createBloodDrips(bloodDrips, 20);
+            const drips = document.createElement('div');
+            drips.className = 'blood-drips';
+            loadingScreen.appendChild(drips);
+            createBloodDrips(drips, 15);
         }
 
-        // Loading messages
-        const messages = [
-            "INITIALIZING BLOOD PUMPS...",
-            "CALIBRATING VIOLENCE...",
-            "LOADING THE MACHINE...",
-            "COMPILING UNHOLY ASSETS...",
-            "MANKIND IS DEAD...",
-            "BLOOD IS FUEL...",
-            "WEBSITE IS FULL..."
-        ];
+        setTimeout(() => {
+            leftGate.classList.add('open');
+            rightGate.classList.add('open');
+        }, 500);
 
-        let messageIndex = 0;
-        let progress = 0;
-        let musicPaused = false;
-
-        // Update loading progress
-        const loadingInterval = setInterval(() => {
-            // More consistent progress increment
-            const increment = Math.random() * 5 + 2; // 2-7% increment
-            progress += increment;
-            if (progress > 100) progress = 100;
-
-            // Update bar width with smoother transition
-            loadingBar.style.transition = 'width 0.3s ease-out';
-            loadingBar.style.width = progress + '%';
-            
-            // Update percentage text
-            loadingPercent.textContent = Math.floor(progress) + '%';
-            
-            // More dynamic glitch effect on the loading bar
-            if (Math.random() > 0.7) {
-                loadingBarGlitch.style.opacity = Math.random() * 0.5;
-                loadingBarGlitch.style.left = (Math.random() * progress) + '%';
-                loadingBarGlitch.style.width = (5 + Math.random() * 20) + '%';
-                
-                setTimeout(() => {
-                    loadingBarGlitch.style.opacity = '0';
-                }, 150);
+        setTimeout(() => {
+            if (typeof introMusic !== 'undefined' && typeof fadeAudio === 'function') {
+                fadeAudio(introMusic, 0, 1000, () => introMusic.pause());
             }
-
-            // Update message with typing effect
-            if (messageIndex < messages.length) {
-                loadingText.textContent = messages[messageIndex];
-                messageIndex++;
+            if (typeof dropMusic !== 'undefined' && typeof playAudioWithFallback === 'function') {
+                playAudioWithFallback(dropMusic);
             }
+            loadingScreen.classList.add('hidden');
 
-            // When we reach 70%, pause the intro music and show weapon pickup
-            if (progress >= 70 && !musicPaused) {
-                musicPaused = true;
-
-                // Fade out the intro music
-                if (typeof introMusic !== 'undefined' && typeof fadeAudio === 'function') {
-                    fadeAudio(introMusic, 0, 1000, function() {
-                        introMusic.pause();
-
-                        // Add a weapon pickup animation/effect
-                        const weaponPickup = document.createElement('div');
-                        weaponPickup.className = 'weapon-pickup';
-                        weaponPickup.innerHTML = `
-                            <div class="pickup-container">
-                                <div class="weapon-icon"></div>
-                                <div class="pickup-text">
-                                    <div class="pickup-title">REVOLVER ACQUIRED</div>
-                                    <div class="pickup-desc">THE HUMBLE BEGINNING OF ALL VIOLENCE</div>
-                                </div>
-                            </div>
-                        `;
-                        loadingScreen.appendChild(weaponPickup);
-
-                        // Create blood splatter effect
-                        if (typeof createBloodSplatterBurst === 'function') {
-                            createBloodSplatterBurst(10, window.innerWidth/2, window.innerHeight/2, 150, 1500);
-                        }
-
-                        // Remove the weapon pickup after animation completes
-                        setTimeout(() => {
-                            if (weaponPickup.parentNode) {
-                                weaponPickup.remove();
-                            }
-                        }, 2500);
-                    });
-                }
-            }
-
-            if (progress === 100) {
-                clearInterval(loadingInterval);
-                // Final message - only after weapon pickup is gone
-                setTimeout(() => {
-                    loadingText.textContent = "WELCOME TO HELL";
-                    
-                    // Final percentage pulse effect
-                    loadingPercent.classList.add('complete');
-
-                    // Play the drop section of the music
-                    if (typeof dropMusic !== 'undefined' && typeof playAudioWithFallback === 'function') {
-                        playAudioWithFallback(dropMusic);
-                    }
-
-                    // Intensify the final effect
-                    loadingScreen.classList.add('final-stage');
-
-                    // Trigger even more blood splatter for the finale
-                    if (typeof createBloodSplatterBurst === 'function') {
-                        createBloodSplatterBurst(20, null, null, 300, 2000);
-                    }
-
-                    // Hide loading screen after delay - longer to match music drop
-                    setTimeout(() => {
-                        loadingScreen.classList.add('hidden');
-
-                        // Instead of fading out completely, just reduce volume
-                        if (typeof dropMusic !== 'undefined' && typeof fadeAudio === 'function') {
-                            fadeAudio(dropMusic, 0.2, 2000);
-                        }
-
-                        // Remove loading screen from DOM after transition
-                        setTimeout(() => {
-                            loadingScreen.remove();
-                            
-                            // Initialize site features after loading completes
-                            initSiteFeatures();
-                        }, 1500);
-                        
-                        // Let drop.mp3 play until it naturally ends
-                        if (typeof dropMusic !== 'undefined') {
-                            dropMusic.addEventListener('ended', function() {
-                                // Fade out music gradually at the end
-                                if (typeof fadeAudio === 'function') {
-                                    fadeAudio(dropMusic, 0, 1000, function() {
-                                        dropMusic.pause();
-                                        dropMusic.remove();
-                                    });
-                                }
-                            });
-                        }
-                    }, 3000); // Longer delay to enjoy the drop
-                }, 1000); // Delay to ensure weapon pickup has completed.
-            }
-        }, 400);
+            setTimeout(() => {
+                loadingScreen.remove();
+                initSiteFeatures();
+            }, 1500);
+        }, 3000);
     }
 
     // Initialize site features (runs for both new and returning visitors)


### PR DESCRIPTION
## Summary
- redesign loading screen as a hell-gate walk-through
- drop loading bar and weapon pickup popup
- fade out to site when gates open

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f5dc1b0608323bebc5212261da878