### PR TITLE
Revamp home page into mission console and add debugger

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -778,3 +778,158 @@ input[type="submit"]:active, button:active {
         font-size: 16px;
     }
 }
+/* Debugging console */
+.machine-debugger {
+    position: fixed;
+    bottom: 88px;
+    right: 24px;
+    width: min(320px, 90vw);
+    max-height: min(60vh, 420px);
+    background: rgba(10, 10, 10, 0.92);
+    border: 1px solid rgba(255, 48, 0, 0.35);
+    border-radius: 14px;
+    box-shadow: 0 0 18px rgba(255, 48, 0, 0.25);
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    overflow: hidden;
+    opacity: 0;
+    transform: translateY(12px);
+    pointer-events: none;
+    transition: opacity var(--transition-medium), transform var(--transition-medium);
+    z-index: 9999;
+}
+
+.machine-debugger.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+.machine-debugger__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.6rem 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 0.75rem;
+    color: rgba(255, 223, 199, 0.75);
+    background: rgba(255, 48, 0, 0.08);
+    border-bottom: 1px solid rgba(255, 48, 0, 0.25);
+}
+
+.machine-debugger__actions {
+    display: flex;
+    gap: 0.4rem;
+}
+
+.machine-debugger__button {
+    border: 1px solid rgba(255, 48, 0, 0.4);
+    background: rgba(12, 12, 12, 0.85);
+    color: rgba(255, 223, 199, 0.85);
+    font-family: var(--font-secondary);
+    font-size: 0.7rem;
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+}
+
+.machine-debugger__button:hover,
+.machine-debugger__button:focus-visible {
+    box-shadow: 0 0 10px rgba(255, 48, 0, 0.3);
+}
+
+.machine-debugger__logs {
+    padding: 0.75rem;
+    display: grid;
+    gap: 0.6rem;
+    overflow-y: auto;
+    font-size: 0.72rem;
+}
+
+.machine-debugger__log {
+    border-left: 3px solid rgba(255, 48, 0, 0.6);
+    padding: 0.4rem 0.55rem;
+    background: rgba(6, 6, 6, 0.85);
+    color: rgba(255, 232, 214, 0.85);
+    display: grid;
+    gap: 0.3rem;
+}
+
+.machine-debugger__log[data-level="info"] {
+    border-color: rgba(0, 200, 255, 0.6);
+}
+
+.machine-debugger__log[data-level="warn"] {
+    border-color: rgba(255, 196, 0, 0.7);
+}
+
+.machine-debugger__log[data-level="error"] {
+    border-color: rgba(255, 72, 0, 0.85);
+}
+
+.machine-debugger__meta {
+    display: flex;
+    justify-content: space-between;
+    color: rgba(255, 223, 199, 0.6);
+    font-size: 0.68rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+}
+
+.machine-debugger__message {
+    word-break: break-word;
+}
+
+.machine-debugger__context {
+    font-family: var(--font-secondary);
+    background: rgba(0, 0, 0, 0.5);
+    padding: 0.4rem 0.45rem;
+    border-radius: 8px;
+    color: rgba(255, 232, 214, 0.7);
+    white-space: pre-wrap;
+}
+
+.machine-debugger__toggle {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 48, 0, 0.35);
+    background: rgba(10, 10, 10, 0.9);
+    color: rgba(255, 223, 199, 0.85);
+    font-family: var(--font-secondary);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    box-shadow: 0 0 14px rgba(255, 48, 0, 0.25);
+    z-index: 9999;
+}
+
+.machine-debugger__toggle:hover,
+.machine-debugger__toggle:focus-visible {
+    box-shadow: 0 0 18px rgba(255, 48, 0, 0.35);
+}
+
+.machine-debugger__empty {
+    color: rgba(255, 223, 199, 0.6);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    text-align: center;
+    padding: 1.6rem 0;
+}
+
+@media (max-width: 640px) {
+    .machine-debugger {
+        right: 12px;
+        left: 12px;
+        width: auto;
+    }
+
+    .machine-debugger__toggle {
+        right: 12px;
+        bottom: 12px;
+    }
+}

--- a/css/pages/home.css
+++ b/css/pages/home.css
@@ -1,459 +1,861 @@
 /* ==================== */
-/* HOME PAGE STYLES */
+/* HOME PAGE REVAMP     */
 /* ==================== */
 
-/* Home Section Styling */
-#home {
-    position: relative;
-    overflow: hidden;
-}
-
-#home::after {
-    content: "";
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
-    background: radial-gradient(circle at center, rgba(255, 48, 0, 0.08), transparent 70%);
-    z-index: 0;
-    pointer-events: none;
-}
-
-#home p {
-    position: relative;
-    margin-bottom: 20px;
-    font-size: 18px;
-    line-height: 1.8;
-    text-shadow: 0 0 3px rgba(0, 0, 0, 0.8);
-    transition: all var(--transition-medium) ease;
-    z-index: 1;
+/* Global adjustments for the Machine Layer */
+body.machine-layer {
     font-family: var(--font-secondary);
+    color: #f4e9db;
+    background: radial-gradient(circle at top, rgba(10, 10, 10, 0.8) 0%, rgba(5, 5, 5, 0.95) 55%, #030202 100%);
+    letter-spacing: 0.02em;
 }
 
-#home p:last-child {
-    margin-bottom: 0;
-}
-
-#home a {
-    color: var(--blood-red);
-    font-weight: bold;
-    transition: all var(--transition-medium) ease;
-    position: relative;
-    z-index: 2;
-    text-shadow: 0 0 3px var(--shadow-red);
+body.machine-layer h1,
+body.machine-layer h2,
+body.machine-layer h3,
+body.machine-layer h4 {
     font-family: var(--font-primary);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
 }
 
-#home a:hover {
-    color: var(--text-light);
-    text-shadow: 0 0 10px var(--blood-red);
-}
-
-/* Rules Section */
-#rules {
-    position: relative;
-}
-
-.ruleboard {
-    font-weight: bold;
-    font-size: x-large;
-    padding: 25px;
-    border: 1px solid var(--dark-red);
-    margin-top: 20px;
-    transition: all var(--transition-medium) ease;
-    position: relative;
-    background: rgba(0, 0, 0, 0.4);
-    box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.6);
-    font-family: var(--font-secondary);
-    border-radius: var(--radius-sm);
-}
-
-.ruleboard::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: radial-gradient(circle at top right, rgba(255, 48, 0, 0.05), transparent 70%);
-    z-index: 0;
-    pointer-events: none;
-}
-
-.ruleboard p {
-    margin: 15px 0;
-    position: relative;
-    padding-left: 30px;
-    z-index: 1;
-    text-shadow: 0 0 3px rgba(0, 0, 0, 0.9);
-    transition: all var(--transition-medium) ease;
-}
-
-.ruleboard p:before {
-    position: absolute;
-    left: 0;
-    content: ">>";
-    color: var(--blood-red);
-    transition: all var(--transition-medium) ease;
-    font-size: 20px;
-    line-height: 1.2;
-}
-
-.ruleboard p:hover {
-    transform: translateX(10px);
-    color: var(--text-light);
-    text-shadow: 0 0 8px var(--blood-red);
-}
-
-.ruleboard p:hover:before {
-    color: var(--text-light);
-    text-shadow: 0 0 8px var(--blood-red);
-}
-
-/* About Section */
-#about {
-    position: relative;
-}
-
-#about p {
-    font-size: 17px;
-    margin-bottom: 15px;
-    position: relative;
-    z-index: 1;
-    font-family: var(--font-secondary);
-}
-
-/* Projects Section */
-#projects .section-title {
-    margin-bottom: 30px;
-}
-
-/* Contact Section */
-#contact {
-    position: relative;
-}
-
-#contact p {
-    font-size: 17px;
-    margin-bottom: 15px;
-    transition: all var(--transition-medium) ease;
-    font-family: var(--font-secondary);
-}
-
-#contact p:first-of-type {
-    font-size: 18px;
-    font-weight: bold;
-    margin-bottom: 20px;
-    color: var(--blood-red);
-    letter-spacing: 1px;
-    font-family: var(--font-primary);
-}
-
-#contact p:not(:first-of-type) {
-    padding: 10px 15px;
-    border-left: 3px solid var(--dark-red);
-    background-color: rgba(0, 0, 0, 0.3);
-    transition: all var(--transition-medium) ease;
-    display: inline-block;
-    width: auto;
-    min-width: 250px;
-    margin-right: 10px;
-    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-}
-
-#contact p:not(:first-of-type):hover {
-    background-color: rgba(255, 48, 0, 0.1);
-    border-left: 3px solid var(--blood-red);
-    transform: translateX(5px);
-    color: var(--text-light);
-    box-shadow: 0 0 10px rgba(255, 48, 0, 0.2);
-}
-
-/* Animated Skill Meters */
-.skills-container {
-    margin-top: 30px;
+body.machine-layer .site-shell.container {
+    width: min(1200px, 95vw);
+    margin: 0 auto;
+    padding: clamp(1.5rem, 3vw, 3rem) 0 clamp(4rem, 6vw, 6rem);
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: clamp(2.5rem, 5vw, 4rem);
+    position: relative;
+    z-index: 2;
+}
+
+.crt-overlay {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 48, 0, 0.04) 0,
+        rgba(255, 48, 0, 0.04) 1px,
+        transparent 1px,
+        transparent 3px
+    );
+    mix-blend-mode: screen;
+    opacity: 0.4;
+    z-index: 1;
+    animation: crt-flicker 4s infinite;
+}
+
+@keyframes crt-flicker {
+    0%, 100% { opacity: 0.35; }
+    45% { opacity: 0.42; }
+    55% { opacity: 0.3; }
+}
+
+/* HERO */
+.hero-control-deck {
+    position: relative;
+    padding: clamp(2.5rem, 5vw, 4rem);
+    background: radial-gradient(circle at top left, rgba(255, 48, 0, 0.08), transparent 65%),
+                linear-gradient(145deg, rgba(20, 20, 20, 0.95) 0%, rgba(10, 10, 10, 0.92) 45%, rgba(5, 5, 5, 0.98) 100%);
+    border: 1px solid rgba(255, 48, 0, 0.18);
+    border-radius: 18px;
+    box-shadow: 0 0 35px rgba(255, 48, 0, 0.16);
+    overflow: hidden;
+}
+
+.hero-control-deck::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, transparent 0%, rgba(255, 48, 0, 0.06) 50%, transparent 100%);
+    mix-blend-mode: screen;
+    pointer-events: none;
+}
+
+.hero-grid {
+    display: grid;
+    gap: clamp(2rem, 4vw, 3.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     position: relative;
     z-index: 1;
 }
 
-.skill-entry {
-    display: grid;
-    grid-template-columns: 250px 1fr 150px;
-    gap: 15px;
-    align-items: center;
+.hero-kicker {
+    font-size: 0.85rem;
+    color: #ffd7a8;
+    letter-spacing: 0.3em;
+    margin-bottom: 1rem;
 }
 
-.skill-label {
-    color: var(--text-dim);
-    font-size: 13px;
-    text-align: right;
+.hero-title {
+    font-size: clamp(2.8rem, 6vw, 4.2rem);
+    margin-bottom: 0.25rem;
+    color: var(--blood-red);
+    text-shadow: 0 0 35px rgba(255, 48, 0, 0.6);
+}
+
+.hero-tagline {
+    margin-bottom: clamp(1.5rem, 3vw, 2.5rem);
+    color: rgba(255, 223, 199, 0.85);
+    font-size: 1rem;
     text-transform: uppercase;
-    transition: color var(--transition-medium) ease;
+    letter-spacing: 0.08em;
 }
 
-.skill-bar {
-    width: 100%;
-    height: 12px;
-    background-color: #220000;
-    border: 1px solid var(--dark-red);
+/* STYLE METER */
+.style-meter {
+    background: linear-gradient(135deg, rgba(40, 40, 40, 0.9) 0%, rgba(20, 20, 20, 0.92) 100%);
+    border: 1px solid rgba(255, 48, 0, 0.3);
+    border-radius: 14px;
+    padding: clamp(1.5rem, 3vw, 2rem);
+    box-shadow: inset 0 0 0 1px rgba(255, 48, 0, 0.15);
+    backdrop-filter: blur(6px);
+}
+
+.style-meter__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 1rem;
+}
+
+.style-meter__label {
+    font-size: 0.85rem;
+    color: rgba(255, 223, 199, 0.75);
+    letter-spacing: 0.24em;
+}
+
+.style-meter__rank {
+    font-size: 1.1rem;
+    color: #ffe5c0;
+    text-shadow: 0 0 18px rgba(255, 48, 0, 0.5);
+    letter-spacing: 0.16em;
+}
+
+.style-meter__bar {
     position: relative;
+    height: 16px;
+    background: rgba(10, 10, 10, 0.85);
+    border: 1px solid rgba(255, 48, 0, 0.35);
+    border-radius: 999px;
     overflow: hidden;
-    box-shadow: inset 0 1px 3px rgba(0,0,0,0.5);
-    border-radius: var(--radius-sm);
+    margin-bottom: 1.25rem;
 }
 
-.skill-level {
-    height: 100%;
-    width: 0;
-    background: linear-gradient(to right, var(--dark-red), var(--blood-red));
+.style-meter__fill {
     position: absolute;
-    top: 0;
-    left: 0;
-    box-shadow: 0 0 8px rgba(255, 48, 0, 0.3);
-    animation: fillSkill 1.5s cubic-bezier(0.25, 1, 0.5, 1) 0.5s forwards;
-    animation-delay: calc(var(--skill-delay, 0.5s));
+    inset: 0;
+    width: var(--style-level, 87%);
+    background: linear-gradient(90deg, rgba(255, 48, 0, 0.85) 0%, rgba(255, 196, 0, 0.85) 100%);
+    box-shadow: 0 0 12px rgba(255, 48, 0, 0.6);
+    animation: style-flow 6s ease-in-out infinite;
 }
 
-/* Add shimmer effect */
-.skill-level::after {
-    content: '';
+.style-meter__pulse {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 30px;
-    height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255, 100, 100, 0.4), transparent);
-    opacity: 0.8;
-    animation: skillShimmer 2s ease-in-out infinite;
-    animation-delay: 2s;
+    inset: 0;
+    background: radial-gradient(circle at 80% 50%, rgba(255, 255, 255, 0.4), transparent 55%);
+    mix-blend-mode: screen;
+    animation: pulse-sweep 3s linear infinite;
 }
 
-.skill-rank {
-    color: var(--blood-red);
-    font-size: 13px;
-    font-weight: bold;
-    transition: color var(--transition-medium) ease;
+@keyframes style-flow {
+    0%, 100% { filter: hue-rotate(0deg); }
+    50% { filter: hue-rotate(-30deg); }
 }
 
-/* New Interactive Home Elements */
-.welcome-badge {
-    position: relative;
-    display: inline-block;
-    background: linear-gradient(to bottom, #3a0000, #220000);
-    color: var(--blood-red);
-    padding: 5px 10px;
-    font-size: 14px;
+@keyframes pulse-sweep {
+    0% { transform: translateX(-90%); opacity: 0; }
+    35% { opacity: 0.7; }
+    60% { opacity: 0; }
+    100% { transform: translateX(110%); opacity: 0; }
+}
+
+.style-meter__readout {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.75rem;
     text-transform: uppercase;
-    font-weight: bold;
-    letter-spacing: 1px;
-    border-radius: var(--radius-sm);
-    margin-bottom: 20px;
-    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.3);
+    font-size: 0.8rem;
 }
 
-.welcome-badge::before {
+.style-meter__readout div {
+    display: grid;
+    gap: 0.2rem;
+    justify-items: start;
+}
+
+.style-meter__readout dt {
+    color: rgba(255, 223, 199, 0.6);
+    letter-spacing: 0.18em;
+}
+
+.style-meter__readout dd {
+    margin: 0;
+    font-weight: bold;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+/* Mission console */
+.mission-console {
+    position: relative;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    gap: 1.5rem;
+    padding: clamp(1.75rem, 3vw, 2.5rem);
+    background: linear-gradient(160deg, rgba(12, 12, 12, 0.92) 0%, rgba(32, 12, 12, 0.88) 100%);
+    border-radius: 16px;
+    border: 1px solid rgba(255, 48, 0, 0.28);
+    box-shadow: 0 0 28px rgba(255, 48, 0, 0.16);
+    overflow: hidden;
+}
+
+.mission-console::before {
     content: "";
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(90deg, 
-        transparent 0%, 
-        rgba(255, 48, 0, 0.3) 50%, 
-        transparent 100%);
-    animation: headerPulse 3s infinite alternate;
-    border-radius: var(--radius-sm);
+    inset: 0;
+    background: repeating-linear-gradient(
+        180deg,
+        rgba(255, 48, 0, 0.08) 0,
+        rgba(255, 48, 0, 0.08) 2px,
+        transparent 2px,
+        transparent 6px
+    );
+    opacity: 0.25;
+    pointer-events: none;
 }
 
-/* Quote Block */
-.quote-block {
-    margin: 30px 0;
-    padding: 20px;
-    border-left: 3px solid var(--blood-red);
-    background-color: rgba(0, 0, 0, 0.3);
-    position: relative;
-    font-style: italic;
-    color: var(--text-dim);
-    font-family: var(--font-secondary);
-    transition: all var(--transition-medium) ease;
-    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-}
-
-.quote-block::before {
-    content: "\u201D";
+.mission-console::after {
+    content: "";
     position: absolute;
-    top: 0;
-    left: 10px;
-    font-size: 60px;
-    line-height: 1;
-    color: var(--dark-red);
-    opacity: 0.5;
-    font-family: var(--font-primary);
+    inset: 0;
+    background: linear-gradient(90deg, rgba(255, 48, 0, 0.1), transparent 30%, transparent 70%, rgba(255, 48, 0, 0.08));
+    mix-blend-mode: screen;
+    pointer-events: none;
 }
 
-.quote-block:hover {
-    border-left-color: var(--blood-red);
-    background-color: rgba(255, 48, 0, 0.1);
-    transform: translateX(5px);
-    box-shadow: 0 0 15px rgba(255, 48, 0, 0.2);
+.mission-console__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    text-transform: uppercase;
 }
 
-.quote-block:hover::before {
-    color: var(--blood-red);
+.mission-console__title {
+    letter-spacing: 0.25em;
+    font-size: 0.85rem;
+    color: rgba(255, 223, 199, 0.75);
 }
 
-.quote-source {
-    display: block;
-    text-align: right;
-    margin-top: 10px;
-    font-size: 14px;
-    opacity: 0.8;
-    font-style: normal;
+.mission-console__indicator {
+    font-size: 0.85rem;
+    color: rgba(255, 223, 199, 0.6);
 }
 
-/* Terminal Mode Overrides for Home Page */
-body.terminal-mode #home p,
-body.terminal-mode #about p,
-body.terminal-mode #contact p,
-body.terminal-mode .quote-block {
-    color: var(--terminal-green);
+.mission-console__headline {
+    font-size: clamp(1.3rem, 3vw, 1.8rem);
+    color: #ffbc73;
+    text-shadow: 0 0 18px rgba(255, 188, 115, 0.45);
 }
 
-body.terminal-mode #home a {
-    color: var(--terminal-green);
-    text-shadow: 0 0 3px var(--terminal-dark);
+.mission-console__copy {
+    color: rgba(244, 233, 219, 0.85);
+    line-height: 1.8;
 }
 
-body.terminal-mode #home a:hover {
-    color: var(--text-light);
-    text-shadow: 0 0 10px var(--terminal-green);
+.mission-console__list {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.5rem;
+    color: rgba(255, 232, 214, 0.75);
 }
 
-body.terminal-mode .ruleboard {
-    border-color: var(--terminal-green);
-    background: rgba(0, 10, 0, 0.3);
+.mission-console__list li::marker {
+    color: rgba(255, 48, 0, 0.75);
 }
 
-body.terminal-mode .ruleboard p:before {
-    color: var(--terminal-green);
+.mission-console__controls {
+    display: flex;
+    gap: 1rem;
 }
 
-body.terminal-mode .ruleboard p:hover {
-    text-shadow: 0 0 8px var(--terminal-green);
+.mission-console__button {
+    flex: 1;
+    border: 1px solid rgba(255, 48, 0, 0.4);
+    background: rgba(15, 15, 15, 0.85);
+    color: #ffe4c4;
+    font-family: var(--font-secondary);
+    letter-spacing: 0.18em;
+    padding: 0.75rem 0;
+    border-radius: 999px;
+    transition: transform var(--transition-medium), box-shadow var(--transition-medium);
 }
 
-body.terminal-mode #contact p:not(:first-of-type) {
-    border-left: 3px solid var(--terminal-dark);
-    background-color: rgba(0, 0, 0, 0.3);
+.mission-console__button:hover,
+.mission-console__button:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 0 18px rgba(255, 48, 0, 0.35);
 }
 
-body.terminal-mode #contact p:not(:first-of-type):hover {
-    background-color: rgba(0, 255, 0, 0.05);
-    border-left: 3px solid var(--terminal-green);
-    box-shadow: 0 0 10px rgba(0, 255, 0, 0.2);
+/* Transmission strip */
+.transmissions-strip {
+    position: relative;
+    background: linear-gradient(90deg, rgba(30, 10, 10, 0.9) 0%, rgba(12, 12, 12, 0.9) 100%);
+    border-radius: 14px;
+    padding: clamp(1.2rem, 2.5vw, 1.8rem);
+    overflow: hidden;
 }
 
-body.terminal-mode .welcome-badge {
-    background: linear-gradient(to bottom, #002200, #001100);
-    color: var(--terminal-green);
+.transmissions-strip__glow {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 50%, rgba(255, 48, 0, 0.18), transparent 65%),
+                radial-gradient(circle at 80% 50%, rgba(255, 188, 115, 0.16), transparent 70%);
+    pointer-events: none;
 }
 
-body.terminal-mode .welcome-badge::before {
-    background: linear-gradient(90deg, 
-        transparent 0%, 
-        rgba(0, 255, 0, 0.3) 50%, 
-        transparent 100%);
+.transmissions-strip__content {
+    position: relative;
+    display: grid;
+    gap: 1.25rem;
+    z-index: 1;
 }
 
-body.terminal-mode .quote-block {
-    border-left-color: var(--terminal-dark);
+.section-heading {
+    font-size: clamp(1.2rem, 3vw, 1.6rem);
+    color: #ffd7a8;
+    margin-bottom: 0.3rem;
 }
 
-body.terminal-mode .quote-block:hover {
-    border-left-color: var(--terminal-green);
-    background-color: rgba(0, 255, 0, 0.05);
-    box-shadow: 0 0 15px rgba(0, 255, 0, 0.2);
+.section-subtitle {
+    color: rgba(255, 232, 214, 0.7);
+    font-size: 0.95rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
 }
 
-body.terminal-mode .quote-block::before {
-    color: var(--terminal-dark);
+.transmission-card {
+    display: grid;
+    gap: 1rem;
+    padding: clamp(1.5rem, 3vw, 2rem);
+    background: rgba(6, 6, 6, 0.85);
+    border-radius: 12px;
+    border: 1px solid rgba(255, 48, 0, 0.24);
+    box-shadow: inset 0 0 0 1px rgba(255, 48, 0, 0.1);
 }
 
-body.terminal-mode .quote-block:hover::before {
-    color: var(--terminal-green);
+.transmission-card__header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 0.75rem;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    letter-spacing: 0.2em;
+    color: rgba(255, 223, 199, 0.6);
 }
 
-/* Responsive Design for Home Page */
-@media (max-width: 768px) {
-    .ruleboard {
-        padding: 15px;
-    }
+.transmission-card__title {
+    color: #ffe4c4;
+    font-size: 1.2rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
 
-    .ruleboard p {
-        font-size: 18px;
-    }
+.transmission-card__summary {
+    color: rgba(244, 233, 219, 0.8);
+    line-height: 1.7;
+}
 
-    /* Responsive adjustments for skills */
-    .skill-entry {
+.transmission-card__cta {
+    align-self: start;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1.4rem;
+    background: rgba(255, 48, 0, 0.1);
+    border-radius: 999px;
+    border: 1px solid rgba(255, 48, 0, 0.35);
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: #ffd7a8;
+}
+
+.transmission-card__cta::after {
+    content: '→';
+    font-size: 0.85rem;
+}
+
+.transmission-card__cta:hover,
+.transmission-card__cta:focus-visible {
+    background: rgba(255, 48, 0, 0.2);
+    box-shadow: 0 0 15px rgba(255, 48, 0, 0.35);
+}
+
+/* LAYER LAYOUT */
+.layer-layout {
+    display: grid;
+    grid-template-columns: minmax(140px, 180px) 1fr;
+    gap: clamp(1.5rem, 4vw, 3.5rem);
+}
+
+.layer-rail {
+    position: sticky;
+    top: clamp(1rem, 4vw, 5rem);
+    display: grid;
+    gap: 0.75rem;
+    align-content: start;
+}
+
+.layer-rail__item {
+    display: grid;
+    gap: 0.35rem;
+    padding: 1rem;
+    border-radius: 14px;
+    background: rgba(12, 12, 12, 0.8);
+    border: 1px solid rgba(255, 48, 0, 0.25);
+    color: rgba(255, 223, 199, 0.75);
+    text-align: left;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    transition: transform var(--transition-medium), box-shadow var(--transition-medium), border-color var(--transition-medium);
+}
+
+.layer-rail__item:hover,
+.layer-rail__item:focus-visible {
+    transform: translateX(4px);
+    border-color: rgba(255, 196, 0, 0.55);
+    box-shadow: 0 0 14px rgba(255, 48, 0, 0.25);
+}
+
+.layer-rail__item.is-active {
+    border-color: rgba(255, 196, 0, 0.9);
+    box-shadow: 0 0 22px rgba(255, 48, 0, 0.35);
+    color: #ffe4c4;
+}
+
+.layer-rail__glyph {
+    font-size: 0.8rem;
+}
+
+.layer-rail__label {
+    font-size: 0.9rem;
+}
+
+.layer-rail__hint {
+    font-size: 0.7rem;
+    color: rgba(255, 223, 199, 0.5);
+}
+
+.layer-stack {
+    display: grid;
+    gap: clamp(2rem, 4vw, 3rem);
+}
+
+.layer-panel {
+    scroll-margin-top: 6rem;
+}
+
+.data-slab {
+    position: relative;
+    background: linear-gradient(160deg, rgba(8, 8, 8, 0.92) 0%, rgba(20, 8, 8, 0.9) 100%);
+    border-radius: 18px;
+    border: 1px solid rgba(255, 48, 0, 0.2);
+    min-height: clamp(320px, 46vw, 520px);
+    display: flex;
+    align-items: stretch;
+    overflow: hidden;
+    box-shadow: 0 0 25px rgba(255, 48, 0, 0.18);
+}
+
+.data-slab::before,
+.data-slab::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.data-slab::before {
+    background: linear-gradient(120deg, rgba(255, 48, 0, 0.08), transparent 65%);
+    mix-blend-mode: screen;
+}
+
+.data-slab::after {
+    background: radial-gradient(circle at top right, rgba(255, 188, 115, 0.12), transparent 60%);
+    opacity: 0;
+    transition: opacity var(--transition-medium);
+}
+
+.layer-panel.is-visible .data-slab::after {
+    opacity: 1;
+}
+
+.data-slab__inner {
+    position: relative;
+    padding: clamp(1.8rem, 3.5vw, 2.6rem);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    width: 100%;
+}
+
+.data-slab__content {
+    display: grid;
+    gap: 1.1rem;
+    color: rgba(244, 233, 219, 0.85);
+    line-height: 1.8;
+}
+
+.layer-access {
+    list-style: none;
+    display: grid;
+    gap: 0.6rem;
+    margin: 0;
+    padding: 0;
+}
+
+.layer-access li a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: rgba(255, 223, 199, 0.85);
+}
+
+.layer-access li a::before {
+    content: '↳';
+    color: rgba(255, 48, 0, 0.6);
+}
+
+.section-verse {
+    font-size: 0.9rem;
+    letter-spacing: 0.28em;
+    color: rgba(255, 188, 115, 0.8);
+}
+
+/* Lore tablet */
+.lore-tablet {
+    position: relative;
+    display: grid;
+    gap: 1.25rem;
+    padding: clamp(1.25rem, 2.5vw, 1.8rem);
+    background: rgba(6, 6, 6, 0.85);
+    border-radius: 16px;
+    border: 1px solid rgba(255, 48, 0, 0.25);
+    box-shadow: inset 0 0 0 1px rgba(255, 48, 0, 0.1);
+}
+
+.lore-tablet__screen {
+    min-height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 1.5rem;
+    font-size: 1rem;
+    color: rgba(255, 232, 214, 0.8);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    line-height: 1.8;
+    background: repeating-linear-gradient(0deg, rgba(255, 48, 0, 0.05) 0, rgba(255, 48, 0, 0.05) 2px, transparent 2px, transparent 4px);
+    border-radius: 12px;
+}
+
+.lore-tablet__controls {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+}
+
+.lore-tablet__button {
+    padding: 0.6rem 1.5rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 48, 0, 0.35);
+    background: rgba(12, 12, 12, 0.85);
+    color: rgba(255, 223, 199, 0.9);
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+}
+
+.lore-tablet__button:hover,
+.lore-tablet__button:focus-visible {
+    box-shadow: 0 0 12px rgba(255, 48, 0, 0.3);
+}
+
+/* Badge grid */
+.badge-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: clamp(1rem, 2.5vw, 1.8rem);
+}
+
+.badge-card {
+    position: relative;
+    padding: 1.5rem;
+    border-radius: 14px;
+    background: rgba(10, 10, 10, 0.9);
+    border: 1px solid rgba(255, 48, 0, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(255, 48, 0, 0.08);
+    display: grid;
+    gap: 0.8rem;
+}
+
+.badge-card__icon {
+    font-size: 1.6rem;
+    color: rgba(255, 188, 115, 0.85);
+}
+
+.badge-card__title {
+    font-size: 0.95rem;
+    color: rgba(255, 232, 214, 0.9);
+    letter-spacing: 0.1em;
+}
+
+.badge-card__summary {
+    font-size: 0.85rem;
+    line-height: 1.6;
+    color: rgba(244, 233, 219, 0.75);
+}
+
+.badge-card__rank {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.24em;
+    color: rgba(255, 188, 115, 0.85);
+}
+
+.badge-card::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    left: 50%;
+    bottom: -0.5rem;
+    transform: translate(-50%, 100%);
+    background: rgba(6, 6, 6, 0.95);
+    color: rgba(255, 223, 199, 0.85);
+    padding: 0.6rem 1rem;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 48, 0, 0.3);
+    font-size: 0.75rem;
+    letter-spacing: 0.12em;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--transition-medium), transform var(--transition-medium);
+    width: max-content;
+    max-width: 220px;
+    text-align: center;
+}
+
+.badge-card:hover::after,
+.badge-card:focus-within::after {
+    opacity: 1;
+    transform: translate(-50%, 120%);
+}
+
+/* Projects */
+.projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: clamp(1.2rem, 3vw, 2rem);
+}
+
+.project-card {
+    position: relative;
+    padding: clamp(1.4rem, 2.6vw, 1.9rem);
+    background: rgba(8, 8, 8, 0.92);
+    border-radius: 16px;
+    border: 1px solid rgba(255, 48, 0, 0.25);
+    box-shadow: inset 0 0 0 1px rgba(255, 48, 0, 0.12);
+    display: grid;
+    gap: 0.8rem;
+}
+
+.project-card__title {
+    font-size: 1.05rem;
+    color: rgba(255, 232, 214, 0.85);
+}
+
+.project-card__summary {
+    color: rgba(244, 233, 219, 0.78);
+    line-height: 1.7;
+}
+
+.project-card__footer {
+    font-size: 0.85rem;
+    letter-spacing: 0.18em;
+    color: rgba(255, 188, 115, 0.75);
+}
+
+.project-card__status-light {
+    position: absolute;
+    top: 1.2rem;
+    right: 1.2rem;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    box-shadow: 0 0 14px currentColor;
+    animation: pulse 2.6s ease-in-out infinite;
+}
+
+.project-card[data-status="online"] .project-card__status-light {
+    color: #00ff9d;
+}
+
+.project-card[data-status="pending"] .project-card__status-light {
+    color: #ffcc33;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 0.9; }
+    50% { opacity: 0.4; }
+}
+
+/* Contact console */
+.contact-console {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: clamp(1rem, 3vw, 1.5rem);
+}
+
+.contact-tile {
+    position: relative;
+    padding: clamp(1.4rem, 2.4vw, 1.9rem);
+    background: rgba(6, 6, 6, 0.88);
+    border-radius: 16px;
+    border: 1px solid rgba(255, 48, 0, 0.24);
+    box-shadow: inset 0 0 0 1px rgba(255, 48, 0, 0.12);
+    display: grid;
+    gap: 0.9rem;
+}
+
+.contact-tile__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    font-size: 0.8rem;
+    color: rgba(255, 223, 199, 0.65);
+}
+
+.contact-tile__value {
+    font-size: 1.1rem;
+    letter-spacing: 0.12em;
+    color: rgba(255, 232, 214, 0.9);
+    word-break: break-word;
+}
+
+.contact-tile__action {
+    justify-self: start;
+    padding: 0.55rem 1.4rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 48, 0, 0.35);
+    background: rgba(12, 12, 12, 0.85);
+    color: rgba(255, 223, 199, 0.9);
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+}
+
+.contact-tile__action:hover,
+.contact-tile__action:focus-visible {
+    box-shadow: 0 0 14px rgba(255, 48, 0, 0.3);
+}
+
+.contact-tile__hint {
+    font-size: 0.75rem;
+    letter-spacing: 0.18em;
+    color: rgba(255, 188, 115, 0.7);
+}
+
+.contact-tile.copied {
+    border-color: rgba(0, 255, 157, 0.5);
+    box-shadow: 0 0 18px rgba(0, 255, 157, 0.25);
+}
+
+.contact-tile.copied .contact-tile__state {
+    color: #00ff9d;
+}
+
+/* Glitch divider */
+.glitch-divider {
+    height: 2px;
+    background: linear-gradient(90deg, transparent, rgba(255, 48, 0, 0.4), transparent);
+    position: relative;
+    overflow: hidden;
+}
+
+.glitch-divider::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, rgba(255, 188, 115, 0.6), transparent);
+    transform: translateX(-100%);
+    animation: glitch-travel 6s linear infinite;
+}
+
+@keyframes glitch-travel {
+    0% { transform: translateX(-100%); }
+    45% { transform: translateX(120%); }
+    46%, 100% { transform: translateX(120%); }
+}
+
+/* Footer */
+.site-footer {
+    text-align: center;
+    display: grid;
+    gap: 0.4rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 0.8rem;
+    color: rgba(255, 223, 199, 0.65);
+}
+
+/* Responsive adjustments */
+@media (max-width: 960px) {
+    .layer-layout {
         grid-template-columns: 1fr;
-        text-align: left;
-        gap: 8px;
     }
-    .skill-label { text-align: left; font-size: 12px; }
-    .skill-rank { order: 3; font-size: 12px; }
-    .skill-bar { order: 2; height: 10px; }
-    
-    #contact p:not(:first-of-type) {
-        display: block;
-        width: 100%;
-        margin-right: 0;
+
+    .layer-rail {
+        position: relative;
+        top: auto;
+        display: flex;
+        flex-wrap: wrap;
     }
-    
-    .quote-block {
-        padding: 15px 15px 15px 20px;
-    }
-    
-    .quote-block::before {
-        font-size: 40px;
-        left: 5px;
+
+    .layer-rail__item {
+        flex: 1 1 calc(50% - 0.75rem);
     }
 }
 
-@media (max-width: 480px) {
-    #home p,
-    #about p,
-    #contact p {
-        font-size: 15px;
+@media (max-width: 640px) {
+    .style-meter__readout {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    .ruleboard p {
-        font-size: 16px;
-        padding-left: 25px;
+    .layer-rail {
+        flex-direction: column;
     }
-    .ruleboard p:before { font-size: 16px; }
 
-    .skill-label, .skill-rank { font-size: 11px; }
-    
-    .welcome-badge {
-        font-size: 12px;
-        padding: 4px 8px;
+    .layer-rail__item {
+        flex: 1 1 auto;
     }
-    
-    .quote-block {
-        margin: 20px 0;
-        padding: 15px 10px 15px 15px;
+
+    .data-slab {
+        min-height: auto;
     }
-    
-    .quote-block::before {
-        font-size: 30px;
-    }
-    
-    .quote-source {
-        font-size: 12px;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+        scroll-behavior: auto !important;
     }
 }

--- a/index.html
+++ b/index.html
@@ -17,410 +17,314 @@
         <link rel="stylesheet" href="css/terminal-mode.css">
         <!-- Page-specific CSS -->
         <link rel="stylesheet" href="css/pages/home.css">
-        <style>
-        body {
-            background: #181818;
-            color: #f4e9db;
-            font-family: 'Share Tech Mono', monospace;
-        }
-        .container {
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: 0 1em;
-        }
-        .header {
-            text-align: center;
-            margin: 2em 0;
-        }
-        .title {
-            font-size: 3em;
-            color: #f43030;
-            text-shadow: 0 0 20px #f43030;
-            margin: 0;
-            letter-spacing: 0.1em;
-        }
-        .subhead {
-            color: #ffd700;
-            font-size: 1.2em;
-            margin: 0.5em 0;
-            letter-spacing: 0.08em;
-        }
-        .subtitle {
-            color: #f4e9db;
-            font-size: 1em;
-            margin: 0.5em 0;
-            letter-spacing: 0.05em;
-        }
-        .hud-style-meter {
-            background: #222;
-            color: #f43030;
-            border: 2px solid #f43030;
-            padding: 0.6em 1.5em;
-            margin: 1em auto 1.5em;
-            display: block;
-            width: fit-content;
-            border-radius: 8px;
-            box-shadow: 0 0 8px #f43030;
-            text-align: center;
-        }
-        .style-rank.blink {
-            animation: blink 1.5s infinite;
-        }
-        @keyframes blink {
-            0%, 50% { opacity: 1; }
-            51%, 100% { opacity: 0.3; }
-        }
-        .marquee {
-            background: #101010;
-            border: 2px solid #f43030;
-            margin: 1.5em 0;
-            overflow: hidden;
-            white-space: nowrap;
-            padding: 0.8em 0;
-        }
-        .marquee-content {
-            display: inline-block;
-            animation: scroll 30s linear infinite;
-            color: #f43030;
-            font-weight: bold;
-        }
-        @keyframes scroll {
-            0% { transform: translateX(100%); }
-            100% { transform: translateX(-100%); }
-        }
-        .ascii-gate {
-            display: block;
-            margin: 1.5em auto;
-            padding: 0;
-            background: transparent;
-            border: none;
-            cursor: pointer;
-            font-family: 'Share Tech Mono', monospace;
-            color: #f43030;
-            font-size: 1.25em;
-            transition: color 0.2s, text-shadow 0.2s;
-            text-align: center;
-            white-space: pre;
-            outline: none;
-        }
-        .ascii-gate:hover, .ascii-gate:focus {
-            color: #fff;
-            text-shadow: 0 0 9px #f43030, 0 0 2px #fff;
-        }
-        .section-panel {
-            background: #232323;
-            border: 2px solid #f43030;
-            border-radius: 10px;
-            box-shadow: 0 0 16px #f4303066;
-            max-width: 800px;
-            margin: 2em auto;
-            padding: 2em 2em 1.5em 2em;
-            display: none;
-            animation: fadeIn 0.25s;
-        }
-        .section-panel.open {
-            display: block;
-        }
-        .section-title {
-            color: #f43030;
-            font-size: 1.5em;
-            margin-bottom: 1em;
-            text-shadow: 0 0 10px #f43030;
-            letter-spacing: 0.1em;
-        }
-        .ruleboard {
-            background: #1a1a1a;
-            border: 1px solid #f43030;
-            padding: 1.5em;
-            margin: 1em 0;
-            border-radius: 5px;
-        }
-        .skills-container {
-            margin: 1.5em 0;
-        }
-        .skill-entry {
-            display: flex;
-            align-items: center;
-            margin: 1em 0;
-            gap: 1em;
-        }
-        .skill-label {
-            flex: 1;
-            font-size: 0.9em;
-            color: #f4e9db;
-        }
-        .skill-bar {
-            flex: 1;
-            height: 20px;
-            background: #333;
-            border: 1px solid #f43030;
-            border-radius: 3px;
-            overflow: hidden;
-            position: relative;
-        }
-        .skill-level {
-            height: 100%;
-            background: linear-gradient(90deg, #f43030, #ffd700);
-            width: var(--level);
-            transition: width 0.5s ease;
-        }
-        .skill-rank {
-            flex: 0 0 auto;
-            font-size: 0.8em;
-            color: #ffd700;
-        }
-        .projects {
-            display: grid;
-            gap: 1.5em;
-            margin: 1.5em 0;
-        }
-        .project-card {
-            background: #1a1a1a;
-            border: 1px solid #f43030;
-            border-radius: 8px;
-            padding: 1.5em;
-            position: relative;
-        }
-        .status-light {
-            position: absolute;
-            top: 1em;
-            right: 1em;
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            animation: pulse 2s infinite;
-        }
-        .status-light.online {
-            background: #00ff00;
-            box-shadow: 0 0 8px #00ff00;
-        }
-        .status-light.pending {
-            background: #ffff00;
-            box-shadow: 0 0 8px #ffff00;
-        }
-        @keyframes pulse {
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.5; }
-        }
-        .nav a {
-            color: #f43030;
-            text-decoration: none;
-            margin: 0.5em 0;
-            display: inline-block;
-            transition: color 0.2s;
-        }
-        .nav a:hover {
-            color: #fff;
-            text-shadow: 0 0 5px #f43030;
-        }
-        .footer {
-            background: #101010e0;
-            color: #f43030;
-            text-align: center;
-            padding: 0.7em 0;
-            font-size: 1em;
-            border-top: 2px solid #f43030;
-            letter-spacing: 0.08em;
-            margin-top: 3em;
-            user-select: none;
-        }
-        @keyframes fadeIn {
-            from { opacity: 0; transform: scale(0.97);}
-            to   { opacity: 1; transform: scale(1);}
-        }
-        </style>
     </head>
-<body>
-    <div class="container">
-        <!-- HEADER -->
-        <header class="header">
-            <h1 class="title">ULTRALAYER</h1>
-            <p class="subhead">THE MACHINE LAYER</p>
-            <p class="subtitle">// MANKIND IS DEAD. BLOOD IS FUEL. WEBSITE IS FULL. //</p>
+<body class="machine-layer">
+    <div class="crt-overlay" aria-hidden="true"></div>
+    <div class="container site-shell">
+        <!-- HERO CONTROL DECK -->
+        <header class="hero-control-deck" id="top">
+            <div class="hero-grid">
+                <div class="hero-column hero-column--identity">
+                    <p class="hero-kicker">THE MACHINE LAYER</p>
+                    <h1 class="hero-title">ULTRALAYER</h1>
+                    <p class="hero-tagline">// MANKIND IS DEAD. BLOOD IS FUEL. WEBSITE IS FULL. //</p>
+
+                    <section class="style-meter" aria-label="Style Meter">
+                        <div class="style-meter__header">
+                            <span class="style-meter__label">STYLE</span>
+                            <span class="style-meter__rank" data-style-rank>DESTRUCTIVE</span>
+                        </div>
+                        <div class="style-meter__bar" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="87">
+                            <span class="style-meter__fill"></span>
+                            <span class="style-meter__pulse" aria-hidden="true"></span>
+                        </div>
+                        <dl class="style-meter__readout">
+                            <div>
+                                <dt>SYNC</dt>
+                                <dd>93%</dd>
+                            </div>
+                            <div>
+                                <dt>FUEL</dt>
+                                <dd>STABLE</dd>
+                            </div>
+                            <div>
+                                <dt>NOISE</dt>
+                                <dd>CONTROLLED</dd>
+                            </div>
+                        </dl>
+                    </section>
+                </div>
+
+                <div class="hero-column hero-column--brief">
+                    <section class="mission-console" aria-label="Mission Brief" data-mission-console>
+                        <header class="mission-console__header">
+                            <p class="mission-console__title">CURRENT DIRECTIVE</p>
+                            <p class="mission-console__indicator" aria-live="polite">// 01 //</p>
+                        </header>
+                        <div class="mission-console__body">
+                            <h2 class="mission-console__headline" data-mission-headline>CALIBRATE THE STYLE METER</h2>
+                            <p class="mission-console__copy" data-mission-copy>
+                                Bring order to the chaos. Polish the Machine Layer until it gleams, but keep the blood-warm hum that makes ULTRAKILL sing.
+                            </p>
+                            <ul class="mission-console__list" data-mission-list>
+                                <li>Audit every layer for clarity and flow.</li>
+                                <li>Route visitors with a rail instead of loose gates.</li>
+                                <li>Let the console breathe with readable type.</li>
+                            </ul>
+                        </div>
+                        <footer class="mission-console__controls">
+                            <button class="mission-console__button" type="button" data-mission-nav="prev" aria-label="Previous directive">PREV</button>
+                            <button class="mission-console__button" type="button" data-mission-nav="next" aria-label="Next directive">NEXT</button>
+                        </footer>
+                    </section>
+                </div>
+            </div>
         </header>
 
-        <!-- HUD Element -->
-        <div class="hud-style-meter">
-            STYLE // <span class="style-rank blink">DESTRUCTIVE</span>
+        <!-- LATEST TRANSMISSIONS -->
+        <section class="transmissions-strip" aria-labelledby="transmissions-title">
+            <div class="transmissions-strip__glow" aria-hidden="true"></div>
+            <div class="transmissions-strip__content">
+                <h2 id="transmissions-title" class="section-heading">Latest Transmissions</h2>
+                <article class="transmission-card" data-transmission-card>
+                    <header class="transmission-card__header">
+                        <p class="transmission-card__status" data-transmission-status>SYNCING…</p>
+                        <p class="transmission-card__timestamp" data-transmission-date>Awaiting signal</p>
+                    </header>
+                    <div class="transmission-card__body">
+                        <h3 class="transmission-card__title" data-transmission-title>Establishing uplink to the archive</h3>
+                        <p class="transmission-card__summary" data-transmission-summary>
+                            The Machine Layer is pulling your most recent log. Stand by while the holo-card materialises.
+                        </p>
+                    </div>
+                    <footer class="transmission-card__footer">
+                        <a class="transmission-card__cta" data-transmission-link href="blog.html">Browse the full archive</a>
+                    </footer>
+                </article>
+            </div>
+        </section>
+
+        <!-- LAYERED LAYOUT -->
+        <div class="layer-layout">
+            <nav class="layer-rail" aria-label="Layer selector">
+                <button class="layer-rail__item is-active" type="button" data-target="layer-entry">
+                    <span class="layer-rail__glyph">00</span>
+                    <span class="layer-rail__label">Entry</span>
+                    <span class="layer-rail__hint">Initialize</span>
+                </button>
+                <button class="layer-rail__item" type="button" data-target="layer-doctrines">
+                    <span class="layer-rail__glyph">01</span>
+                    <span class="layer-rail__label">Doctrines</span>
+                    <span class="layer-rail__hint">Core Law</span>
+                </button>
+                <button class="layer-rail__item" type="button" data-target="layer-profile">
+                    <span class="layer-rail__glyph">02</span>
+                    <span class="layer-rail__label">Profile</span>
+                    <span class="layer-rail__hint">System Bio</span>
+                </button>
+                <button class="layer-rail__item" type="button" data-target="layer-projects">
+                    <span class="layer-rail__glyph">03</span>
+                    <span class="layer-rail__label">Projects</span>
+                    <span class="layer-rail__hint">Active Logs</span>
+                </button>
+                <button class="layer-rail__item" type="button" data-target="layer-contact">
+                    <span class="layer-rail__glyph">04</span>
+                    <span class="layer-rail__label">Contact</span>
+                    <span class="layer-rail__hint">Transmit</span>
+                </button>
+            </nav>
+
+            <main class="layer-stack">
+                <section id="layer-entry" class="layer-panel" data-layer-index="0">
+                    <div class="data-slab" data-animate>
+                        <div class="data-slab__inner">
+                            <header class="data-slab__header">
+                                <h2 class="section-heading">Layer 00 // Entry Point</h2>
+                                <p class="section-subtitle">A console spun up in honour of ULTRAKILL's machine gospel.</p>
+                            </header>
+                            <div class="data-slab__content">
+                                <p>
+                                    Welcome to the Machine Layer. The old accordion gates have been replaced with a continuous control room so you can see every subsystem without opening hatch after hatch.
+                                </p>
+                                <p>
+                                    This site runs on a simple promise: keep the ULTRAKILL attitude, but let visitors navigate without friction. Scroll, follow the rail, and descend.
+                                </p>
+                                <ul class="layer-access">
+                                    <li><a href="music.html">Access the Music Rack</a></li>
+                                    <li><a href="blog.html">Read the Transmission Archive</a></li>
+                                    <li><a href="sins.html">Review Recorded Sins</a></li>
+                                    <li><a href="pong.html">Enter the Recreation Node</a></li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <div class="glitch-divider" aria-hidden="true"></div>
+
+                <section id="layer-doctrines" class="layer-panel" data-layer-index="1">
+                    <div class="data-slab" data-animate>
+                        <div class="data-slab__inner">
+                            <header class="data-slab__header">
+                                <h2 class="section-heading">Layer 01 // Core Doctrines</h2>
+                                <p class="section-subtitle">Immutable law, cycling on a holotablet pulled from the council archives.</p>
+                            </header>
+                            <div class="data-slab__content">
+                                <section class="lore-tablet" aria-live="polite" data-lore-tablet>
+                                    <div class="lore-tablet__screen" data-lore-output>
+                                        // DIRECTIVE 01: MANKIND IS DEAD. THEIR REIGN IS OVER. ONLY THE ECHO REMAINS. //
+                                    </div>
+                                    <div class="lore-tablet__controls">
+                                        <button class="lore-tablet__button" type="button" data-lore-nav="prev" aria-label="Previous directive">PREV</button>
+                                        <button class="lore-tablet__button" type="button" data-lore-nav="next" aria-label="Next directive">NEXT</button>
+                                    </div>
+                                </section>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <div class="glitch-divider" aria-hidden="true"></div>
+
+                <section id="layer-profile" class="layer-panel" data-layer-index="2">
+                    <div class="data-slab" data-animate>
+                        <div class="data-slab__inner">
+                            <header class="data-slab__header">
+                                <h2 class="section-heading">Layer 02 // System Profile</h2>
+                                <p class="section-subtitle">Signal bleed between flesh and machine; a ghost steering cameras, code, and cathodes.</p>
+                            </header>
+                            <div class="data-slab__content">
+                                <p>
+                                    Designation uncertain. I keep one foot in the arena and the other in the editor, stitching audiovisual hellscapes and interface experiments together until the styles align.
+                                </p>
+                                <p class="section-verse">"WHAT HAS BEEN WILL BE AGAIN." ECCLESIASTES 1:9 //</p>
+                                <p>
+                                    Translation: recycle the bones of the old internet with new sinew. Each badge below lights up a capability currently in rotation.
+                                </p>
+                                <div class="badge-grid" role="list">
+                                    <article class="badge-card" role="listitem" data-tooltip="Precision route planning for every arena.">
+                                        <header>
+                                            <p class="badge-card__icon" aria-hidden="true">⟟</p>
+                                            <h3 class="badge-card__title">Digital Hell Navigation</h3>
+                                        </header>
+                                        <p class="badge-card__summary">ULTRAKILL strategy mapping, enemy readouts, style-optimised pathing.</p>
+                                        <p class="badge-card__rank" aria-label="Rank A badge">Rank A</p>
+                                    </article>
+                                    <article class="badge-card" role="listitem" data-tooltip="Gradient sorcery, CRT bloom, responsive bloodshed.">
+                                        <header>
+                                            <p class="badge-card__icon" aria-hidden="true">✶</p>
+                                            <h3 class="badge-card__title">Retrowave Interface Craft</h3>
+                                        </header>
+                                        <p class="badge-card__summary">CSS compositing, emissive frames, ULTRAKILL-fluent component design.</p>
+                                        <p class="badge-card__rank" aria-label="Rank A- badge">Rank A-</p>
+                                    </article>
+                                    <article class="badge-card" role="listitem" data-tooltip="Video pipelines tuned for righteous carnage.">
+                                        <header>
+                                            <p class="badge-card__icon" aria-hidden="true">◈</p>
+                                            <h3 class="badge-card__title">Data Stream Manipulation</h3>
+                                        </header>
+                                        <p class="badge-card__summary">Capture, edit, and stabilise footage drenched in blood-fuelled kinetic energy.</p>
+                                        <p class="badge-card__rank" aria-label="Rank B+ badge">Rank B+</p>
+                                    </article>
+                                    <article class="badge-card" role="listitem" data-tooltip="APIs, shaders, and the rituals that keep them steady.">
+                                        <header>
+                                            <p class="badge-card__icon" aria-hidden="true">⚙</p>
+                                            <h3 class="badge-card__title">Logic Gate Construction</h3>
+                                        </header>
+                                        <p class="badge-card__summary">Web architecture, build tooling, and reactive UI choreography.</p>
+                                        <p class="badge-card__rank" aria-label="Rank A badge">Rank A</p>
+                                    </article>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <div class="glitch-divider" aria-hidden="true"></div>
+
+                <section id="layer-projects" class="layer-panel" data-layer-index="3">
+                    <div class="data-slab" data-animate>
+                        <div class="data-slab__inner">
+                            <header class="data-slab__header">
+                                <h2 class="section-heading">Layer 03 // Active Transmissions</h2>
+                                <p class="section-subtitle">Live objectives running through the Machine Layer right now.</p>
+                            </header>
+                            <div class="data-slab__content">
+                                <div class="projects-grid">
+                                    <article class="project-card" data-status="online">
+                                        <div class="project-card__status-light" aria-hidden="true"></div>
+                                        <h3 class="project-card__title">Project: UNDERTIDE</h3>
+                                        <p class="project-card__summary">A drowned world-system blueprint waiting for the right surge of power. Systems are staged, assets archived, activation imminent.</p>
+                                        <p class="project-card__footer">Status: HIBERNATING</p>
+                                    </article>
+                                    <article class="project-card" data-status="pending">
+                                        <div class="project-card__status-light" aria-hidden="true"></div>
+                                        <h3 class="project-card__title">Objective: PERFECTION</h3>
+                                        <p class="project-card__summary">The grind for S-ranks and flawless execution. Every failure loops back through the blood pumps until mastery hits critical mass.</p>
+                                        <p class="project-card__footer">Status: JUDGEMENT PENDING</p>
+                                    </article>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <div class="glitch-divider" aria-hidden="true"></div>
+
+                <section id="layer-contact" class="layer-panel" data-layer-index="4">
+                    <div class="data-slab" data-animate>
+                        <div class="data-slab__inner">
+                            <header class="data-slab__header">
+                                <h2 class="section-heading">Layer 04 // Contact Console</h2>
+                                <p class="section-subtitle">Patch into the comms grid. Tiles flicker, but the data routes are hardened.</p>
+                            </header>
+                            <div class="data-slab__content">
+                                <p>
+                                    Direct comms to the Bluesky coordinate below. Each tile copies details to your clipboard for faster redeployment.
+                                </p>
+                                <div class="contact-console">
+                                    <article class="contact-tile" data-channel="bluesky">
+                                        <header class="contact-tile__header">
+                                            <p class="contact-tile__label">Bluesky</p>
+                                            <span class="contact-tile__state">LIVE</span>
+                                        </header>
+                                        <p class="contact-tile__value" data-contact-value="@nito4.bsky.social">@nito4.bsky.social</p>
+                                        <button class="contact-tile__action" type="button" data-copy-button>
+                                            COPY
+                                        </button>
+                                        <p class="contact-tile__hint" aria-live="polite">Tap to copy</p>
+                                    </article>
+                                    <article class="contact-tile" data-channel="email">
+                                        <header class="contact-tile__header">
+                                            <p class="contact-tile__label">Fallback Relay</p>
+                                            <span class="contact-tile__state">STANDBY</span>
+                                        </header>
+                                        <p class="contact-tile__value" data-contact-value="ultralayer@protonmail.com">ultralayer@protonmail.com</p>
+                                        <button class="contact-tile__action" type="button" data-copy-button>
+                                            COPY
+                                        </button>
+                                        <p class="contact-tile__hint" aria-live="polite">Tap to copy</p>
+                                    </article>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </main>
         </div>
 
-        <!-- MARQUEE -->
-        <div class="marquee">
-            <div class="marquee-content">
-                ++ CONNECTION ESTABLISHED ++ WELCOME TO THE MACHINE LAYER // SURVIVAL NOT GUARANTEED // BLOOD IS THE CURRENCY // DATA IS THE SOUL // HELL IS A SERVER RACK // ARE YOU STILL READING THIS? ++ SIGNAL UNSTABLE ++
-            </div>
-        </div>
-
-        <!-- HOME: Open by default -->
-        <section id="home-panel" class="section-panel open">
-            <h2 class="section-title">ENTRY POINT // LAYER 0</h2>
-            <p>INITIALIZING PROTOCOLS... WELCOME, TRAVELER, OR PERHAPS... MACHINE?</p>
-            <p>CONSIDER THIS YOUR TERMINAL INTO THE MACHINE LAYER. A DIGITAL CIRCLE FORGED IN HOMAGE TO THE SACRED, BLOODY TEXTS OF <a href="https://store.steampowered.com/app/1229490/ULTRAKILL/" target="_blank" rel="noopener">ULTRAKILL</a>.</p>
-            <p>MANKIND IS DEAD. BLOOD IS FUEL. THIS WEBSITE IS FULL. THE ECHOES REMAIN.</p>
-            <p>GO DEEPER, IF YOUR PROCESSORS CAN HANDLE THE LOAD. THE ABYSS BECKONS.</p>
-        </section>
-
-        <!-- NAV GATE -->
-        <button class="ascii-gate" data-target="nav-panel" aria-expanded="false">
-{ NAV }
-  _____
- /     \\
-|  [+]  |
- \\_____/
-        </button>
-        <nav id="nav-panel" class="section-panel nav" aria-hidden="true">
-            <h2 class="section-title">NAVIGATION</h2>
-            <a href="#home-panel">HOME</a> <br>
-            <a href="#about-panel">ABOUT</a> <br>
-            <a href="#projects-panel">PROJECTS</a> <br>
-            <a href="music.html">MUSIC</a> <br>
-            <a href="blog.html">BLOG</a> <br>
-            <a href="#contact-panel">CONTACT</a> <br>
-            <a href="sins.html">SINS</a> <br>
-            <a href="/pong.html">PONG</a>
-        </nav>
-
-        <!-- RULES GATE -->
-        <button class="ascii-gate" data-target="rules-panel" aria-expanded="false">
-{ RULES }
-  _____
- /     \\
-|  [+]  |
- \\_____/
-        </button>
-        <section id="rules-panel" class="section-panel" aria-hidden="true">
-            <h2 class="section-title">THE CORE DOCTRINES // IMMUTABLE LAW</h2>
-            <div class="ruleboard">
-                <p>// DIRECTIVE 01: MANKIND IS DEAD. THEIR REIGN IS OVER. ONLY THE ECHO REMAINS. //</p>
-                <p>// DIRECTIVE 02: BLOOD IS FUEL. THE ESSENCE OF THE FALLEN POWERS THE MACHINE. //</p>
-                <p>// DIRECTIVE 03: HELL IS FULL. THERE IS ALWAYS ROOM FOR ONE MORE LAYER. //</p>
-            </div>
-        </section>
-
-        <!-- ABOUT GATE -->
-        <button class="ascii-gate" data-target="about-panel" aria-expanded="false">
-{ ABOUT }
-  _____
- /     \\
-|  [+]  |
- \\_____/
-        </button>
-        <section id="about-panel" class="section-panel" aria-hidden="true">
-            <h2 class="section-title">SYSTEM PROFILE // UNIT IDENTIFICATION</h2>
-            <p>DESIGNATION: HUMAN? MACHINE? THE DISTINCTION BLURS WITHIN THESE CIRCUITS. A GHOST IN THE MACHINE LAYER, PERHAPS. I MANIFEST DATA STREAMS—VIDEO, CODE, AND THE OCCASIONAL DESCENT INTO ULTRAKILL'S BLOODY CATHEDRALS.</p>
-            <p>"What has been will be again, what has been done will be done again; there is nothing new under the sun." - Ecclesiastes 1:9. // YET WE REBUILD THE OLD HELLS IN NEW DIGITAL FORMS. //</p>
-            <p>MY OPERATING PARAMETERS // SYSTEM CAPABILITIES:</p>
-
-            <!-- Skills Revamped -->
-            <div class="skills-container">
-                <div class="skill-entry">
-                    <span class="skill-label">DIGITAL HELL NAVIGATION (ULTRAKILL)</span>
-                    <div class="skill-bar">
-                        <div class="skill-level" style="--level: 90%;"></div> 
-                    </div>
-                    <span class="skill-rank">[RANK: A]</span>
-                </div>
-                <div class="skill-entry">
-                    <span class="skill-label">RETROWAVE AESTHETICS (CSS)</span>
-                    <div class="skill-bar">
-                        <div class="skill-level" style="--level: 80%;"></div> 
-                    </div>
-                     <span class="skill-rank">[CALIBRATING...]</span>
-                </div>
-                <div class="skill-entry">
-                    <span class="skill-label">DATA STREAM MANIPULATION (VIDEO)</span>
-                    <div class="skill-bar">
-                        <div class="skill-level" style="--level: 70%;"></div> 
-                    </div>
-                    <span class="skill-rank">[PROCESSING...]</span>
-                </div>
-                <div class="skill-entry">
-                    <span class="skill-label">LOGIC GATE CONSTRUCTION (WEB DEV)</span>
-                    <div class="skill-bar">
-                        <div class="skill-level" style="--level: 85%;"></div> 
-                    </div>
-                    <span class="skill-rank">[FUNCTIONAL]</span>
-                </div>
-            </div>
-            <p>//SYSTEM STATUS: NOMINALLY OPERATIONAL//</p>
-        </section>
-
-        <!-- PROJECTS GATE -->
-        <button class="ascii-gate" data-target="projects-panel" aria-expanded="false">
-{ PROJECTS }
-  _____
- /     \\
-|  [+]  |
- \\_____/
-        </button>
-        <section id="projects-panel" class="section-panel" aria-hidden="true">
-            <h2 class="section-title">ACTIVE TRANSMISSIONS // PROJECT LOGS</h2>
-            <div class="projects">
-                <!-- Project Card Structure Remains -->
-                <div class="project-card">
-                    <div class="status-light online"></div> 
-                    <h3>PROJECT: UNDERTIDE</h3>
-                    <p>A nascent world-system blueprint. Drowned echoes within the code, awaiting subroutine activation. Status: HIBERNATING.</p>
-                </div>
-                <div class="project-card">
-                    <div class="status-light pending"></div> 
-                    <h3>OBJECTIVE: PERFECTION (ULTRAKILL)</h3>
-                    <p>The pursuit of flawless execution. An eternal cycle of bloodshed and optimization. Infinite hyperdeath loops. Status: //JUDGEMENT PENDING//</p>
-                </div>
-            </div>
-        </section>
-
-        <!-- CONTACT GATE -->
-        <button class="ascii-gate" data-target="contact-panel" aria-expanded="false">
-{ CONTACT }
-  _____
- /     \\
-|  [+]  |
- \\_____/
-        </button>
-        <section id="contact-panel" class="section-panel" aria-hidden="true">
-            <h2 class="section-title">ESTABLISH CONTACT // TRANSMISSION PROTOCOLS</h2>
-            <p>ROUTE YOUR DATA PACKETS TO THE FOLLOWING DESIGNATED COORDINATE:</p>
-            <p>COORDINATE LOCK (BLUESKY): @nito4.bsky.social</p>
-            <p>// WARNING: Signal integrity across layers cannot be guaranteed. Response latency variable. The machine processes as it wills. //</p>
-        </section>
+        <footer class="site-footer">
+            <p>© <span id="current-year">2025</span> ULTRALAYER // BEST EXPERIENCED WITH NETSCAPE NAVIGATOR 4.0 OR HIGHER //</p>
+            <p id="last-updated">FORGED IN BLOOD AND CODE // LAST SYSTEM UPDATE: MARCH 23, 2025</p>
+        </footer>
     </div>
 
-    <!-- FOOTER (With ID for dynamic date) -->
-    <footer class="footer">
-        <p>© <span id="current-year">2025</span> ULTRALAYER // THIS TERMINAL BEST VIEWED WITH NETSCAPE NAVIGATOR 4.0 OR HIGHER // REALITY IS OPTIONAL</p>
-        <p id="last-updated">FORGED IN BLOOD AND CODE // LAST SYSTEM UPDATE: MARCH 23, 2025</p>
-    </footer>
-
-    <script>
-    // Gate logic: toggle corresponding panels
-    document.querySelectorAll('.ascii-gate').forEach(gate => {
-        gate.addEventListener('click', function() {
-            const targetId = this.getAttribute('data-target');
-            const panel = document.getElementById(targetId);
-            const expanded = this.getAttribute('aria-expanded') === 'true';
-            if (!expanded) {
-                panel.classList.add('open');
-                panel.setAttribute('aria-hidden', 'false');
-                this.setAttribute('aria-expanded', 'true');
-                this.innerHTML = this.innerHTML.replace('[+]', '[-]');
-            } else {
-                panel.classList.remove('open');
-                panel.setAttribute('aria-hidden', 'true');
-                this.setAttribute('aria-expanded', 'false');
-                this.innerHTML = this.innerHTML.replace('[-]', '[+]');
-            }
-        });
-    });
-
-    // Set current year dynamically
-    document.getElementById('current-year').textContent = new Date().getFullYear();
-    </script>
-
     <!-- JavaScript Files -->
-    <script src="js/core.js"></script>
-    <script src="js/audio.js"></script>
-    <script src="js/effects.js"></script>
-    <script src="js/terminal.js"></script>
+    <script src="js/debugger.js"></script>
+    <script src="js/home.js" defer></script>
+    <script src="js/core.js" defer></script>
+    <script src="js/audio.js" defer></script>
+    <script src="js/effects.js" defer></script>
+    <script src="js/terminal.js" defer></script>
 </body>
 </html>

--- a/js/core.js
+++ b/js/core.js
@@ -19,6 +19,8 @@ document.addEventListener('DOMContentLoaded', function() {
         lastUpdatedP.textContent = `${prefix}${month} ${day}, ${year}`;
     }
 
+    const siteShell = document.querySelector('.site-shell') || document.querySelector('.container');
+
     // Check if we've already been through the intro
     const hasVisitedBefore = sessionStorage.getItem('ultraLayerVisited');
     
@@ -56,13 +58,17 @@ document.addEventListener('DOMContentLoaded', function() {
         document.body.appendChild(startScreen);
 
         // Hide everything else until user clicks
-        document.querySelector('.container').style.display = 'none';
+        if (siteShell) {
+            siteShell.style.display = 'none';
+        }
 
         // When user clicks the start screen, remove it and show the site
         startScreen.addEventListener('click', function() {
             // Enable audio (this click will allow autoplay)
             startScreen.remove();
-            document.querySelector('.container').style.display = 'block';
+            if (siteShell) {
+                siteShell.style.display = 'block';
+            }
 
             // Set flag for visited
             sessionStorage.setItem('ultraLayerVisited', 'true');

--- a/js/debugger.js
+++ b/js/debugger.js
@@ -1,0 +1,210 @@
+(function (global) {
+    class MachineDebugger {
+        constructor(options = {}) {
+            this.maxLogs = Number.isInteger(options.maxLogs) ? options.maxLogs : 100;
+            this.logs = [];
+            this.visible = false;
+            this.autoAttach = options.autoAttach !== false;
+            this.hasDOM = typeof document !== 'undefined' && !!document.body;
+
+            if (this.hasDOM) {
+                this.setupUI();
+                this.setupToggle();
+                if (this.autoAttach) {
+                    this.attachGlobalHandlers();
+                }
+            }
+        }
+
+        setupUI() {
+            this.panel = document.createElement('section');
+            this.panel.className = 'machine-debugger';
+            this.panel.setAttribute('role', 'region');
+            this.panel.setAttribute('aria-live', 'polite');
+
+            const header = document.createElement('div');
+            header.className = 'machine-debugger__header';
+            header.innerHTML = '<span>Diagnostics</span>';
+
+            const actions = document.createElement('div');
+            actions.className = 'machine-debugger__actions';
+
+            this.clearButton = document.createElement('button');
+            this.clearButton.type = 'button';
+            this.clearButton.textContent = 'Clear';
+            this.clearButton.className = 'machine-debugger__button';
+            this.clearButton.addEventListener('click', () => this.clear());
+
+            this.collapseButton = document.createElement('button');
+            this.collapseButton.type = 'button';
+            this.collapseButton.textContent = 'Hide';
+            this.collapseButton.className = 'machine-debugger__button';
+            this.collapseButton.addEventListener('click', () => this.hide());
+
+            actions.appendChild(this.clearButton);
+            actions.appendChild(this.collapseButton);
+            header.appendChild(actions);
+
+            this.logList = document.createElement('div');
+            this.logList.className = 'machine-debugger__logs';
+            this.logList.dataset.state = 'empty';
+            this.logList.innerHTML = '<div class="machine-debugger__empty">Awaiting logs</div>';
+
+            this.panel.appendChild(header);
+            this.panel.appendChild(this.logList);
+            document.body.appendChild(this.panel);
+        }
+
+        setupToggle() {
+            this.toggle = document.createElement('button');
+            this.toggle.className = 'machine-debugger__toggle';
+            this.toggle.type = 'button';
+            this.toggle.setAttribute('aria-expanded', 'false');
+            this.toggle.textContent = 'DBG';
+            this.toggle.addEventListener('click', () => {
+                this.visible ? this.hide() : this.show();
+            });
+
+            document.body.appendChild(this.toggle);
+
+            document.addEventListener('keydown', (event) => {
+                if (event.key.toLowerCase() === 'd' && (event.ctrlKey || event.metaKey)) {
+                    event.preventDefault();
+                    this.visible ? this.hide() : this.show();
+                }
+            });
+        }
+
+        attachGlobalHandlers() {
+            if (typeof window !== 'undefined') {
+                window.addEventListener('error', (event) => {
+                    this.error('Unhandled error', {
+                        message: event.message,
+                        source: event.filename,
+                        line: event.lineno,
+                    });
+                });
+
+                window.addEventListener('unhandledrejection', (event) => {
+                    this.error('Unhandled promise rejection', {
+                        reason: event.reason && event.reason.message ? event.reason.message : String(event.reason),
+                    });
+                });
+            }
+        }
+
+        createLogEntry(level, message, context, timestamp) {
+            if (!this.hasDOM) {
+                return null;
+            }
+            const wrapper = document.createElement('div');
+            wrapper.className = 'machine-debugger__log';
+            wrapper.dataset.level = level;
+
+            const meta = document.createElement('div');
+            meta.className = 'machine-debugger__meta';
+            meta.innerHTML = `<span>${level}</span><span>${timestamp.toLocaleTimeString()}</span>`;
+
+            const messageEl = document.createElement('div');
+            messageEl.className = 'machine-debugger__message';
+            messageEl.textContent = message;
+
+            wrapper.appendChild(meta);
+            wrapper.appendChild(messageEl);
+
+            if (context && Object.keys(context).length > 0) {
+                const contextEl = document.createElement('div');
+                contextEl.className = 'machine-debugger__context';
+                contextEl.textContent = MachineDebugger.stringifyContext(context);
+                wrapper.appendChild(contextEl);
+            }
+
+            return wrapper;
+        }
+
+        log(level, message, context = {}) {
+            const timestamp = new Date();
+            const entry = { level, message, context, timestamp };
+            this.logs.push(entry);
+            if (this.logs.length > this.maxLogs) {
+                this.logs.shift();
+                if (this.hasDOM && this.logList.firstChild) {
+                    this.logList.removeChild(this.logList.firstChild);
+                }
+            }
+
+            if (this.hasDOM && this.logList) {
+                if (this.logList.dataset.state === 'empty') {
+                    this.logList.dataset.state = 'ready';
+                    this.logList.innerHTML = '';
+                }
+                const domEntry = this.createLogEntry(level, message, context, timestamp);
+                if (domEntry) {
+                    this.logList.appendChild(domEntry);
+                    this.logList.scrollTop = this.logList.scrollHeight;
+                }
+            }
+            return entry;
+        }
+
+        info(message, context) {
+            return this.log('info', message, context);
+        }
+
+        warn(message, context) {
+            return this.log('warn', message, context);
+        }
+
+        error(message, context) {
+            return this.log('error', message, context);
+        }
+
+        clear() {
+            this.logs = [];
+            if (this.hasDOM && this.logList) {
+                this.logList.dataset.state = 'empty';
+                this.logList.innerHTML = '<div class="machine-debugger__empty">Awaiting logs</div>';
+            }
+        }
+
+        show() {
+            if (!this.hasDOM) return;
+            this.visible = true;
+            this.panel.classList.add('is-visible');
+            this.toggle.setAttribute('aria-expanded', 'true');
+        }
+
+        hide() {
+            if (!this.hasDOM) return;
+            this.visible = false;
+            this.panel.classList.remove('is-visible');
+            this.toggle.setAttribute('aria-expanded', 'false');
+        }
+
+        static stringifyContext(context) {
+            try {
+                return JSON.stringify(context, null, 2);
+            } catch (error) {
+                return '[Unserializable context]';
+            }
+        }
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = { MachineDebugger };
+    }
+
+    if (global && typeof global.document !== 'undefined') {
+        const boot = () => {
+            if (!global.machineDebugger) {
+                global.machineDebugger = new MachineDebugger();
+            }
+        };
+
+        if (global.document.readyState === 'loading') {
+            global.document.addEventListener('DOMContentLoaded', boot);
+        } else {
+            boot();
+        }
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/home.js
+++ b/js/home.js
@@ -1,0 +1,458 @@
+const fallbackMotionQuery = {
+    matches: false,
+    addEventListener: () => {},
+    addListener: () => {},
+};
+
+const prefersReducedMotion =
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+        ? window.matchMedia('(prefers-reduced-motion: reduce)')
+        : fallbackMotionQuery;
+
+function onMotionPreferenceChange(callback) {
+    if (typeof prefersReducedMotion.addEventListener === 'function') {
+        prefersReducedMotion.addEventListener('change', callback);
+    } else if (typeof prefersReducedMotion.addListener === 'function') {
+        prefersReducedMotion.addListener(callback);
+    }
+}
+
+function debugLog(level, message, context = {}) {
+    const debuggerChannel = window.machineDebugger;
+    if (debuggerChannel && typeof debuggerChannel[level] === 'function') {
+        debuggerChannel[level](message, context);
+    } else if (typeof console !== 'undefined' && typeof console[level] === 'function') {
+        console[level](`[MachineLayer] ${message}`, context);
+    }
+}
+
+function initLayerRail() {
+    const buttons = Array.from(document.querySelectorAll('.layer-rail__item'));
+    const sections = buttons
+        .map((button) => {
+            const id = button.getAttribute('data-target');
+            const section = id ? document.getElementById(id) : null;
+            if (!section) {
+                debugLog('warn', 'Layer rail target missing', { id });
+            }
+            return { button, section, id };
+        })
+        .filter((entry) => entry.section);
+
+    if (!sections.length) {
+        return;
+    }
+
+    const updateActive = (id) => {
+        sections.forEach(({ button, section }) => {
+            const isMatch = section.id === id;
+            button.classList.toggle('is-active', isMatch);
+            button.setAttribute('aria-current', isMatch ? 'true' : 'false');
+            section.classList.toggle('is-visible', isMatch || section.classList.contains('is-visible'));
+        });
+    };
+
+    const scrollToSection = (section) => {
+        if (!section) return;
+        section.scrollIntoView({
+            behavior: prefersReducedMotion.matches ? 'auto' : 'smooth',
+            block: 'start',
+        });
+    };
+
+    sections.forEach(({ button, section }) => {
+        button.addEventListener('click', () => {
+            updateActive(section.id);
+            scrollToSection(section);
+        });
+
+        button.addEventListener('focus', () => {
+            updateActive(section.id);
+        });
+    });
+
+    const observer = new IntersectionObserver(
+        (entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('is-visible');
+                    updateActive(entry.target.id);
+                }
+            });
+        },
+        {
+            threshold: 0.45,
+            rootMargin: '-20% 0px -40% 0px',
+        },
+    );
+
+    sections.forEach(({ section }) => observer.observe(section));
+
+    updateActive(sections[0].section.id);
+    debugLog('info', 'Layer rail initialised', { layers: sections.length });
+}
+
+function initMissionConsole() {
+    const consoleEl = document.querySelector('[data-mission-console]');
+    if (!consoleEl) {
+        return;
+    }
+
+    const indicator = consoleEl.querySelector('.mission-console__indicator');
+    const headline = consoleEl.querySelector('[data-mission-headline]');
+    const copy = consoleEl.querySelector('[data-mission-copy]');
+    const list = consoleEl.querySelector('[data-mission-list]');
+    const buttons = consoleEl.querySelectorAll('[data-mission-nav]');
+
+    const directives = [
+        {
+            headline: 'Calibrate the Style Meter',
+            copy: 'Bring order to the chaos. Polish the Machine Layer until it gleams, but keep the blood-warm hum that makes ULTRAKILL sing.',
+            list: [
+                'Audit every layer for clarity and flow.',
+                'Route visitors with a rail instead of loose gates.',
+                'Let the console breathe with readable type.',
+            ],
+        },
+        {
+            headline: 'Deploy Layer Rail',
+            copy: 'Guide travellers with a persistent selector. Every glyph is a breadcrumb deeper into the stack.',
+            list: [
+                'Stick the rail to the viewport for fast switching.',
+                'Mark active layers with emissive borders.',
+                'Ensure keyboard traversal mirrors pointer control.',
+            ],
+        },
+        {
+            headline: 'Ignite the Mission Feed',
+            copy: 'Surface the newest transmissions automatically so no one wonders if the Machine Layer still hums.',
+            list: [
+                'Pull from the blog archive asynchronously.',
+                'Fallback gracefully when the uplink sputters.',
+                'Log fetch status to the debugging console.',
+            ],
+        },
+        {
+            headline: 'Fortify Accessibility',
+            copy: 'High-energy does not mean hard to read. Contrast stays lethal, focus stays visible.',
+            list: [
+                'Respect reduced-motion preferences across animations.',
+                'Elevate focus outlines on the rail and tiles.',
+                'Increase base type sizes for long-form logs.',
+            ],
+        },
+    ];
+
+    let index = 0;
+    let timerId;
+    const interval = 9000;
+
+    const render = () => {
+        const directive = directives[index];
+        if (!directive) {
+            return;
+        }
+        if (indicator) {
+            indicator.textContent = `// ${String(index + 1).padStart(2, '0')} //`;
+        }
+        if (headline) {
+            headline.textContent = directive.headline.toUpperCase();
+        }
+        if (copy) {
+            copy.textContent = directive.copy;
+        }
+        if (list) {
+            list.innerHTML = '';
+            directive.list.forEach((item) => {
+                const li = document.createElement('li');
+                li.textContent = item;
+                list.appendChild(li);
+            });
+        }
+    };
+
+    const startRotation = () => {
+        if (prefersReducedMotion.matches) {
+            return;
+        }
+        stopRotation();
+        timerId = window.setInterval(() => {
+            index = (index + 1) % directives.length;
+            render();
+        }, interval);
+    };
+
+    const stopRotation = () => {
+        if (timerId) {
+            window.clearInterval(timerId);
+            timerId = undefined;
+        }
+    };
+
+    buttons.forEach((button) => {
+        button.addEventListener('click', () => {
+            const direction = button.getAttribute('data-mission-nav');
+            if (direction === 'prev') {
+                index = (index - 1 + directives.length) % directives.length;
+            } else {
+                index = (index + 1) % directives.length;
+            }
+            render();
+            startRotation();
+        });
+    });
+
+    consoleEl.addEventListener('mouseenter', stopRotation);
+    consoleEl.addEventListener('mouseleave', startRotation);
+
+    onMotionPreferenceChange(() => {
+        if (prefersReducedMotion.matches) {
+            stopRotation();
+        } else {
+            startRotation();
+        }
+    });
+
+    render();
+    startRotation();
+    debugLog('info', 'Mission console initialised', { directives: directives.length });
+}
+
+async function initTransmissions() {
+    const card = document.querySelector('[data-transmission-card]');
+    if (!card) {
+        return;
+    }
+
+    const statusEl = card.querySelector('[data-transmission-status]');
+    const titleEl = card.querySelector('[data-transmission-title]');
+    const summaryEl = card.querySelector('[data-transmission-summary]');
+    const dateEl = card.querySelector('[data-transmission-date]');
+    const linkEl = card.querySelector('[data-transmission-link]');
+
+    try {
+        const response = await fetch('blog_data.json', { cache: 'no-store' });
+        if (!response.ok) {
+            throw new Error(`Unexpected status: ${response.status}`);
+        }
+        const data = await response.json();
+        if (!Array.isArray(data) || data.length === 0) {
+            throw new Error('No transmissions available');
+        }
+        const latest = data[0];
+        if (statusEl) {
+            statusEl.textContent = 'LIVE FEED';
+        }
+        if (titleEl) {
+            titleEl.textContent = latest.title || 'Transmission Online';
+        }
+        if (summaryEl) {
+            summaryEl.textContent = latest.summary || 'A new dispatch has arrived from the archive.';
+        }
+        if (dateEl) {
+            dateEl.textContent = latest.date ? `Last ping: ${latest.date}` : 'Last ping: Active';
+        }
+        if (linkEl) {
+            linkEl.href = latest.file || 'blog.html';
+            linkEl.textContent = 'Read full log';
+        }
+        card.dataset.state = 'ready';
+        debugLog('info', 'Latest transmission loaded', { title: latest.title });
+    } catch (error) {
+        card.dataset.state = 'error';
+        if (statusEl) {
+            statusEl.textContent = 'OFFLINE';
+        }
+        if (summaryEl) {
+            summaryEl.textContent = 'Signal unstable. Check back soon or dive straight into the archive.';
+        }
+        if (dateEl) {
+            dateEl.textContent = 'Last ping: Unknown';
+        }
+        if (linkEl) {
+            linkEl.textContent = 'Open archive';
+            linkEl.href = 'blog.html';
+        }
+        debugLog('error', 'Failed to load latest transmission', { error: error.message });
+    }
+}
+
+function initLoreTablet() {
+    const tablet = document.querySelector('[data-lore-tablet]');
+    if (!tablet) {
+        return;
+    }
+
+    const output = tablet.querySelector('[data-lore-output]');
+    const buttons = tablet.querySelectorAll('[data-lore-nav]');
+
+    const directives = [
+        '// DIRECTIVE 01: MANKIND IS DEAD. THEIR REIGN IS OVER. ONLY THE ECHO REMAINS. //',
+        '// DIRECTIVE 02: BLOOD IS FUEL. THE ESSENCE OF THE FALLEN POWERS THE MACHINE. //',
+        '// DIRECTIVE 03: HELL IS FULL. THERE IS ALWAYS ROOM FOR ONE MORE LAYER. //',
+        '// DIRECTIVE 04: STYLE IS LAW. CHAOS WITHOUT FORM IS JUST NOISE. //',
+    ];
+
+    let index = 0;
+    let timerId;
+    const interval = 7000;
+
+    const render = () => {
+        if (output) {
+            output.textContent = directives[index];
+        }
+    };
+
+    const startRotation = () => {
+        if (prefersReducedMotion.matches) {
+            return;
+        }
+        stopRotation();
+        timerId = window.setInterval(() => {
+            index = (index + 1) % directives.length;
+            render();
+        }, interval);
+    };
+
+    const stopRotation = () => {
+        if (timerId) {
+            window.clearInterval(timerId);
+            timerId = undefined;
+        }
+    };
+
+    buttons.forEach((button) => {
+        button.addEventListener('click', () => {
+            const direction = button.getAttribute('data-lore-nav');
+            if (direction === 'prev') {
+                index = (index - 1 + directives.length) % directives.length;
+            } else {
+                index = (index + 1) % directives.length;
+            }
+            render();
+            startRotation();
+        });
+    });
+
+    onMotionPreferenceChange(() => {
+        if (prefersReducedMotion.matches) {
+            stopRotation();
+        } else {
+            startRotation();
+        }
+    });
+
+    render();
+    startRotation();
+}
+
+function initContactConsole() {
+    const buttons = document.querySelectorAll('[data-copy-button]');
+    if (!buttons.length) {
+        return;
+    }
+
+    buttons.forEach((button) => {
+        button.addEventListener('click', async () => {
+            const tile = button.closest('.contact-tile');
+            if (!tile) return;
+            const valueEl = tile.querySelector('[data-contact-value]');
+            const hint = tile.querySelector('.contact-tile__hint');
+            const value = valueEl ? valueEl.textContent.trim() : '';
+            if (!value) {
+                debugLog('warn', 'Contact value missing', { tile: tile.dataset.channel });
+                if (hint) {
+                    hint.textContent = 'No value to copy';
+                }
+                return;
+            }
+            if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+                debugLog('warn', 'Clipboard API not available', { channel: tile.dataset.channel });
+                if (hint) {
+                    hint.textContent = 'Clipboard unavailable';
+                }
+                return;
+            }
+
+            try {
+                await navigator.clipboard.writeText(value);
+                if (hint) {
+                    hint.textContent = 'Copied to clipboard';
+                }
+                tile.classList.add('copied');
+                debugLog('info', 'Copied contact value', { channel: tile.dataset.channel });
+                window.setTimeout(() => {
+                    tile.classList.remove('copied');
+                    if (hint) {
+                        hint.textContent = 'Tap to copy';
+                    }
+                }, 2500);
+            } catch (error) {
+                debugLog('error', 'Clipboard write failed', { error: error.message });
+                if (hint) {
+                    hint.textContent = 'Copy failed — check console';
+                }
+            }
+        });
+    });
+}
+
+function initStyleMeter() {
+    const bar = document.querySelector('.style-meter__bar');
+    const rankEl = document.querySelector('[data-style-rank]');
+    if (!bar || !rankEl) {
+        return;
+    }
+
+    const ranks = [
+        { threshold: 82, label: 'DESTRUCTIVE' },
+        { threshold: 86, label: 'BRUTAL' },
+        { threshold: 92, label: 'SSSHATTERING' },
+    ];
+
+    const adjustMeter = () => {
+        const level = Math.floor(82 + Math.random() * 12);
+        bar.style.setProperty('--style-level', `${level}%`);
+        bar.setAttribute('aria-valuenow', String(level));
+        const currentRank = ranks.reduce((acc, item) => (level >= item.threshold ? item.label : acc), ranks[0].label);
+        rankEl.textContent = currentRank;
+    };
+
+    adjustMeter();
+
+    let intervalId;
+    const start = () => {
+        if (prefersReducedMotion.matches || intervalId) {
+            return;
+        }
+        intervalId = window.setInterval(adjustMeter, 8000);
+    };
+
+    const stop = () => {
+        if (intervalId) {
+            window.clearInterval(intervalId);
+            intervalId = undefined;
+        }
+    };
+
+    start();
+    onMotionPreferenceChange(() => {
+        if (prefersReducedMotion.matches) {
+            stop();
+        } else {
+            start();
+        }
+    });
+}
+
+function initHomePage() {
+    initLayerRail();
+    initMissionConsole();
+    initTransmissions();
+    initLoreTablet();
+    initContactConsole();
+    initStyleMeter();
+    debugLog('info', 'Home page modules ready');
+}
+
+document.addEventListener('DOMContentLoaded', initHomePage);

--- a/tests/debugger.test.js
+++ b/tests/debugger.test.js
@@ -1,0 +1,24 @@
+const { MachineDebugger } = require('../js/debugger');
+
+describe('MachineDebugger', () => {
+    test('retains the latest logs up to the max limit', () => {
+        const debuggerInstance = new MachineDebugger({ maxLogs: 3, autoAttach: false });
+        debuggerInstance.info('A');
+        debuggerInstance.warn('B');
+        debuggerInstance.error('C');
+        debuggerInstance.info('D');
+
+        expect(debuggerInstance.logs).toHaveLength(3);
+        expect(debuggerInstance.logs[0].message).toBe('B');
+        expect(debuggerInstance.logs[2].message).toBe('D');
+    });
+
+    test('returns a fallback string for unserialisable context', () => {
+        const debuggerInstance = new MachineDebugger({ autoAttach: false });
+        const context = {};
+        context.self = context;
+
+        const result = MachineDebugger.stringifyContext(context);
+        expect(result).toBe('[Unserializable context]');
+    });
+});


### PR DESCRIPTION
## Summary
- rebuild the home page as a continuous ULTRAKILL-inspired control deck with a hero console, sticky layer rail, and redesigned sections styled via css/pages/home.css
- introduce mission rotation, automated transmission feed, holographic skill badges, and an updated contact console powered by new home.js interactions
- add a reusable MachineDebugger overlay with automated logging plus unit tests to cover its log handling utilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d080a0a610832384c9ea11d7e8a3e0